### PR TITLE
use the original HandlerOption type for the handler option

### DIFF
--- a/rlog.go
+++ b/rlog.go
@@ -19,14 +19,19 @@ type groupOrAttrs struct {
 	attrs []slog.Attr
 }
 
+type HandlerOptions struct {
+	AddSource bool
+	Level     slog.Leveler
+}
+
 type RawTextHandler struct {
 	mu     *sync.Mutex
 	writer io.Writer
-	opts   slog.HandlerOptions
+	opts   HandlerOptions
 	goas   []groupOrAttrs
 }
 
-func NewRawTextHandler(w io.Writer, opts *slog.HandlerOptions) *RawTextHandler {
+func NewRawTextHandler(w io.Writer, opts *HandlerOptions) *RawTextHandler {
 	h := &RawTextHandler{
 		mu:     &sync.Mutex{},
 		writer: w,

--- a/rlog_test.go
+++ b/rlog_test.go
@@ -97,6 +97,23 @@ func TestRlogLevel(t *testing.T) {
 	}
 }
 
+func TestRlogSource(t *testing.T) {
+	b := new(bytes.Buffer)
+	logger := slog.New(NewRawTextHandler(b, &HandlerOptions{
+		AddSource: false,
+	}))
+
+	logger.Info("test")
+	assert.NotContains(t, b.String(), "rlog_test.go:")
+
+	b.Reset()
+	loggerWithSource := slog.New(NewRawTextHandler(b, &HandlerOptions{
+		AddSource: true,
+	}))
+	loggerWithSource.Info("test")
+	assert.Contains(t, b.String(), "rlog_test.go:")
+}
+
 func TestRlogWithAttrsAndGroups(t *testing.T) {
 	b := new(bytes.Buffer)
 	logger := slog.New(NewRawTextHandler(b, nil))

--- a/rlog_test.go
+++ b/rlog_test.go
@@ -57,7 +57,7 @@ func TestRlog(t *testing.T) {
 
 func TestRlogLevel(t *testing.T) {
 	b := new(bytes.Buffer)
-	logger := slog.New(NewRawTextHandler(b, &slog.HandlerOptions{
+	logger := slog.New(NewRawTextHandler(b, &HandlerOptions{
 		Level: slog.LevelWarn,
 	}))
 	require.NotNil(t, logger)


### PR DESCRIPTION
- use the original HandlerOption type for the handler option
- add a test to check the source info
